### PR TITLE
Towards a dashboard page

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,0 +1,8 @@
+$(function(){
+  $.ajax({
+    url: '/projects/dashboard',
+    dataType: 'json'
+  }).success(function(data){
+    $('#projects_board').append(data.template)
+  });
+})

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  def root
+  end
 
 	helper_method def logged_in?
 	  !!current_user #double negation to convert to boolean
@@ -11,5 +13,5 @@ class ApplicationController < ActionController::Base
 	helper_method def current_user
 	  @current_user ||= User.find(session[:user_id]) if session[:user_id] #memoized
 	end
-  
+
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,6 +5,11 @@ class ProjectsController < ApplicationController
     @projects = Project.all
   end
 
+  def dashboard
+    @projects = current_user.collaborator.projects
+    data = {template: "<div>#{current_user.name} has contributed to #{@projects.count} projects!</div>"}
+    render :json => data
+  end
 
   def show
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,9 +14,17 @@
 class Project < ActiveRecord::Base
 
 	has_many :collaborators_projects
-	has_many :collaborators, through: :collaborators_projects
+	has_many :collaborators, -> { uniq }, through: :collaborators_projects
+	# the above uses a scope block http://stackoverflow.com/questions/16569994/deprecation-warning-when-using-has-many-through-uniq-in-rails-4
 	has_many :milestones
 	belongs_to :admin
 	delegate :user, to: :admin
+
+	def self.with_the_most_collaborators
+		# Project.select('projects.*,count(collaborators.id) as collaborators_count').joins(:collaborators).group('projects.id').order('collaborators_count desc limit 1')
+		Project.group('projects.id')
+					 .select('projects.*,count(collaborators.id) as collaborators_count')
+					 .joins(:collaborators).order('collaborators_count desc limit 1')[0]
+	end
 
 end

--- a/app/views/application/root.html.erb
+++ b/app/views/application/root.html.erb
@@ -1,0 +1,5 @@
+<% if logged_in? %>
+<div id="projects_board"></div>
+<% else %>
+Show fancy signup/signin page
+<% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -12,7 +12,7 @@
 
 <p>
   <strong>Admin:</strong>
-  <%= @project.admin_id %>
+  <%= link_to @project.admin.user.name, @project.admin.user %>
 </p>
 <div id="collaborators">
   <h3>Collaborators:</h3>
@@ -25,7 +25,7 @@
   </ul>
 </div>
 <div id="milestones">
-  <h3>Milestones:</h3>
+  <h3><%= link_to "Milestones:", project_milestones_path(@project) %></h3>
   <ul>
     <% @project.milestones.each do |milestone| %>
       <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
-  root 'users#index'
+  root 'application#root'
+  get '/projects/dashboard' => 'projects#dashboard'
   get 'sessions/new'
   get 'sessions/create'
   get 'sessions/destroy'

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe Project, type: :model do
 	let(:user1) { FactoryGirl.build(:user) }
 	let(:user2) { FactoryGirl.build(:user) }
 	let(:user3) { FactoryGirl.build(:user) }
-	# let(:admin) { FactoryGirl.build(:admin) }
+	let(:admin) { FactoryGirl.build(:admin) }
 	let(:project) { FactoryGirl.build(:project) }
+
 
 	describe "#project" do
 		# let(:project) { FactoryGirl.build(:project, admin: admin) }
@@ -26,12 +27,60 @@ RSpec.describe Project, type: :model do
 		it "has an admin?" do
 			expect(project.admin).to_not eq nil
 		end
+	end
 
-		# describe "#project can have collaborators" do
-		xit "has collaborators" do
-			project.collaborators = Collaborator.all
-			expect(project.collaborators).to include?(Collaborator.all)
+	describe "#project can have collaborators " do
+		let(:project) { Project.create({name: "Cool Project"}) }
+		let(:user) { User.create({name: "Ian", admin: Admin.new, collaborator: Collaborator.new}) }
+
+		it "is created without collaborators" do
+			expect(project.collaborators).to eq []
+		end
+
+		it "can have collaborators added to it" do
+			project.collaborators << user.collaborator
+			expect(project.collaborators).to include(user.collaborator)
+			expect(user.collaborator.projects).to include(project)
+		end
+
+		it "cannot have the same collaborator added more than once" do
+			project.collaborators << user.collaborator
+			project.collaborators << user.collaborator
+			expect(project.collaborators).to eq [user.collaborator]
 		end
 	end
-end
 
+	describe "#with_the_most_collaborators" do
+		let(:collaborator1) { Collaborator.create }
+		let(:collaborator2) { Collaborator.create }
+		let(:collaborator3) { Collaborator.create }
+		let(:collaborator4) { Collaborator.create }
+		let(:project1) { Project.create({name: "Cool Project"	}) }
+		let(:project2) { Project.create({name: "Decent Project"}) }
+
+		it "returns the project with the most collaborators" do
+			project1.collaborators << collaborator1
+			project1.collaborators << collaborator2
+
+			project2.collaborators << collaborator2
+			project2.collaborators << collaborator3
+			project2.collaborators << collaborator4
+			expect(Project.with_the_most_collaborators).to eq project2
+		end
+
+	end
+
+	describe "#project can have milestones" do
+		let(:project) { Project.create({name: "Cool Project"}) }
+		it "is initialized without milestones" do
+			expect(project.milestones).to eq []
+		end
+
+		it "can have milestones added" do
+			project.milestones << Milestone.create(title: "something good")
+			project.milestones << Milestone.create(title: "even better")
+			expect(project.milestones.count).to eq 2
+		end
+	end
+
+end


### PR DESCRIPTION
In preparation for integrating handlebars on monday, I've made the following changes:

1) I created a new root route, which can be used to serve either a big fancy login page or a helpful project dashboard (if they signup/log in)
2) If the user logs in, the application#root controller action will render a mostly blank page with a few div elements.
3) On page load, an ajax call is fired to '/projects/dashboard'. On success, ajax will take data it receives from the projects#dashboard controller action and append it to the appropriate div element on the root page.
4) The 'projects#dashboard' controller action is a new action I created, and does not correspond to a CRUD action. It is made specifically to handle JSON requests, and will return all of the projects associated with the current_user (i.e. all of the projects current_user has collaborated on).

With the above in place, we can integrate handlebars fairly readily by modifying the projects#dashboard controller action and creating a handlebars template that takes the array of current_user's projects and spits out nicely formatted HTML. 

We can then extend this approach to send data from other controllers to our dashboard, making for a pretty useful main page!
